### PR TITLE
[exporter/dynatrace] add multi-instance deployment note to README.md

### DIFF
--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -259,18 +259,18 @@ Default: `5000`
 ## Cumulative Data Points
 
 When receiving Sum or Histogram metrics with CUMULATIVE temporality, this exporter
-needs to perform CUMULATIVE to DELTA conversion. This conversion can lead to missing
-or inconsistent data, as described below.
+performs CUMULATIVE to DELTA conversion. This conversion can lead to missing
+or inconsistent data, as described below:
 
 ### First Data Points are dropped
 
-Due to the conversion the exporter will drop the first received data point,
-as there is no previous data point to compare it to. This can be circumvented by
-exporting DELTA values from the OpenTelemetry SDK.
+Due to the conversion, the exporter will drop the first received data point,
+as there is no previous data point to compare it to. This can be circumvented
+by configuring the OpenTelemetry SDK to export DELTA values.
 
-### Multi-instance deployment
+### Multi-instance collector deployment
 
-In a multiple-instance deployment of the OpenTelemetry Collector, the conversion
-can produce inconsistent data unless it can be guaranteed that metrics from the
-same source are processed by the same collector instance. This can be circumvented
-by exporting DELTA values from the OpenTelemetry SDK.
+In a multiple-instance deployment of the OpenTelemetry Collector, the conversion 
+can produce inconsistent data unless it can be guaranteed that metrics from the 
+same source are processed by the same collector instance. This can be circumvented 
+by configuring the OpenTelemetry SDK to export DELTA values.

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -27,7 +27,7 @@ To see all available options, see [Advanced Configuration](#advanced-configurati
 > When using this exporter, it is RECOMMENDED to configure your SDKs to export DELTA metrics. 
 > When receiving CUMULATIVE metrics, this exporter will perform CUMULATIVE to DELTA conversions. 
 > In a multiple-instance deployment of the OpenTelemetry Collector this conversion will produce
-> consistent data.
+> inconsistent data.
 
 ### Running alongside Dynatrace OneAgent (preferred)
 

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -25,10 +25,11 @@ All configurations are optional, but if an `endpoint` other than the OneAgent me
 To see all available options, see [Advanced Configuration](#advanced-configuration) below.
 
 > When using this exporter, it is strongly RECOMMENDED to configure the OpenTelemetry SDKs to export metrics
-> with DELTA temporality. When receiving metrics with CUMULATIVE temporality, this exporter 
-> will perform CUMULATIVE to DELTA conversion. In a multiple-instance deployment of the 
-> OpenTelemetry Collector, this conversion can produce inconsistent data unless it can be
-> guaranteed that metrics from the same source are processed by the same collector instance.
+> with DELTA temporality. When receiving Sum or Histogram metrics with CUMULATIVE temporality, this exporter 
+> will perform CUMULATIVE to DELTA conversion, which will drop the first received data point, as there is no
+> previous data point to compare it to. In a multiple-instance deployment of the OpenTelemetry Collector,
+> this conversion can produce inconsistent data unless it can be guaranteed that metrics from the same source
+> are processed by the same collector instance.
 
 ### Running alongside Dynatrace OneAgent (preferred)
 

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -26,7 +26,7 @@ To see all available options, see [Advanced Configuration](#advanced-configurati
 
 > When using this exporter, it is strongly RECOMMENDED to configure the OpenTelemetry SDKs to export metrics 
 > with DELTA temporality. If you are exporting Sum or Histogram metrics with CUMULATIVE temporality, read
-> about possible limitations of this exporter [here](#cumulative-data-points).
+> about possible limitations of this exporter [here](#considerations-when-exporting-cumulative-data-points).
 
 ### Running alongside Dynatrace OneAgent (preferred)
 
@@ -254,21 +254,19 @@ Default: `5000`
 
 **Deprecated: Please use [default_dimensions](#default_dimensions-optional) instead**
 
-# Limitations
-
-## Cumulative Data Points
+# Considerations when exporting Cumulative Data Points
 
 When receiving Sum or Histogram metrics with CUMULATIVE temporality, this exporter
 performs CUMULATIVE to DELTA conversion. This conversion can lead to missing
 or inconsistent data, as described below:
 
-### First Data Points are dropped
+## First Data Points are dropped
 
 Due to the conversion, the exporter will drop the first received data point,
 as there is no previous data point to compare it to. This can be circumvented
 by configuring the OpenTelemetry SDK to export DELTA values.
 
-### Multi-instance collector deployment
+## Multi-instance collector deployment
 
 In a multiple-instance deployment of the OpenTelemetry Collector, the conversion 
 can produce inconsistent data unless it can be guaranteed that metrics from the 

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -24,10 +24,11 @@ The Dynatrace exporter is enabled by adding a `dynatrace` entry to the `exporter
 All configurations are optional, but if an `endpoint` other than the OneAgent metric ingestion endpoint is specified then an `api_token` is required.
 To see all available options, see [Advanced Configuration](#advanced-configuration) below.
 
-> When using this exporter, it is strongly RECOMMENDED to configure your SDKs to export metrics
+> When using this exporter, it is strongly RECOMMENDED to configure the OpenTelemetry SDKs to export metrics
 > with DELTA temporality. When receiving metrics with CUMULATIVE temporality, this exporter 
 > will perform CUMULATIVE to DELTA conversion. In a multiple-instance deployment of the 
-> OpenTelemetry Collector, this conversion can produce inconsistent data.
+> OpenTelemetry Collector, this conversion can produce inconsistent data unless it can be
+> guaranteed that metrics from the same source are processed by the same collector instance.
 
 ### Running alongside Dynatrace OneAgent (preferred)
 

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -24,6 +24,11 @@ The Dynatrace exporter is enabled by adding a `dynatrace` entry to the `exporter
 All configurations are optional, but if an `endpoint` other than the OneAgent metric ingestion endpoint is specified then an `api_token` is required.
 To see all available options, see [Advanced Configuration](#advanced-configuration) below.
 
+> When using this exporter, it is RECOMMENDED to configure your SDKs to export DELTA metrics. 
+> When receiving CUMULATIVE metrics, this exporter will perform CUMULATIVE to DELTA conversions. 
+> In a multiple-instance deployment of the OpenTelemetry Collector this conversion will not produce
+> consistent data.
+
 ### Running alongside Dynatrace OneAgent (preferred)
 
 If you run the Collector on a host or VM that is monitored by the Dynatrace OneAgent then you only need to enable the exporter. No further configurations needed. The Dynatrace exporter will send all metrics to the OneAgent which will use its secure and load balanced connection to send the metrics to your Dynatrace SaaS or Managed environment.

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -24,12 +24,9 @@ The Dynatrace exporter is enabled by adding a `dynatrace` entry to the `exporter
 All configurations are optional, but if an `endpoint` other than the OneAgent metric ingestion endpoint is specified then an `api_token` is required.
 To see all available options, see [Advanced Configuration](#advanced-configuration) below.
 
-> When using this exporter, it is strongly RECOMMENDED to configure the OpenTelemetry SDKs to export metrics
-> with DELTA temporality. When receiving Sum or Histogram metrics with CUMULATIVE temporality, this exporter 
-> will perform CUMULATIVE to DELTA conversion, which will drop the first received data point, as there is no
-> previous data point to compare it to. In a multiple-instance deployment of the OpenTelemetry Collector,
-> this conversion can produce inconsistent data unless it can be guaranteed that metrics from the same source
-> are processed by the same collector instance.
+> When using this exporter, it is strongly RECOMMENDED to configure the OpenTelemetry SDKs to export metrics 
+> with DELTA temporality. If you are exporting Sum or Histogram metrics with CUMULATIVE temporality, read
+> about possible limitations of this exporter [here](#cumulative-data-points).
 
 ### Running alongside Dynatrace OneAgent (preferred)
 
@@ -256,3 +253,24 @@ Default: `5000`
 ### tags (Deprecated, Optional)
 
 **Deprecated: Please use [default_dimensions](#default_dimensions-optional) instead**
+
+# Limitations
+
+## Cumulative Data Points
+
+When receiving Sum or Histogram metrics with CUMULATIVE temporality, this exporter
+needs to perform CUMULATIVE to DELTA conversion. This conversion can lead to missing
+or inconsistent data, as described below.
+
+### First Data Points are dropped
+
+Due to the conversion the exporter will drop the first received data point,
+as there is no previous data point to compare it to. This can be circumvented by
+exporting DELTA values from the OpenTelemetry SDK.
+
+### Multi-instance deployment
+
+In a multiple-instance deployment of the OpenTelemetry Collector, the conversion
+can produce inconsistent data unless it can be guaranteed that metrics from the
+same source are processed by the same collector instance. This can be circumvented
+by exporting DELTA values from the OpenTelemetry SDK.

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -26,7 +26,7 @@ To see all available options, see [Advanced Configuration](#advanced-configurati
 
 > When using this exporter, it is RECOMMENDED to configure your SDKs to export DELTA metrics. 
 > When receiving CUMULATIVE metrics, this exporter will perform CUMULATIVE to DELTA conversions. 
-> In a multiple-instance deployment of the OpenTelemetry Collector this conversion will not produce
+> In a multiple-instance deployment of the OpenTelemetry Collector this conversion will produce
 > consistent data.
 
 ### Running alongside Dynatrace OneAgent (preferred)

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -24,10 +24,10 @@ The Dynatrace exporter is enabled by adding a `dynatrace` entry to the `exporter
 All configurations are optional, but if an `endpoint` other than the OneAgent metric ingestion endpoint is specified then an `api_token` is required.
 To see all available options, see [Advanced Configuration](#advanced-configuration) below.
 
-> When using this exporter, it is RECOMMENDED to configure your SDKs to export DELTA metrics. 
-> When receiving CUMULATIVE metrics, this exporter will perform CUMULATIVE to DELTA conversions. 
-> In a multiple-instance deployment of the OpenTelemetry Collector this conversion will produce
-> inconsistent data.
+> When using this exporter, it is strongly RECOMMENDED to configure your SDKs to export metrics
+> with DELTA temporality. When receiving metrics with CUMULATIVE temporality, this exporter 
+> will perform CUMULATIVE to DELTA conversion. In a multiple-instance deployment of the 
+> OpenTelemetry Collector, this conversion can produce inconsistent data.
 
 ### Running alongside Dynatrace OneAgent (preferred)
 


### PR DESCRIPTION
For internal review:

**Description:** 

This PR adds a note to the `README.md` that the cumulative-to-delta conversion can lead to inconsistent data when using the Exporter in multi-instance Collector deployment.